### PR TITLE
Fix GUI integration typos

### DIFF
--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1,40 +1,41 @@
 #include "gui.h"
-include <imgui.h>
+#include <imgui.h>
 #include <backends/imgui_impl_win32.h>
 #include <backends/imgui_impl_dx11.h>
-include <d3d11.h>
-include <tchar.h>
+#include <d3d11.h>
+#include <tchar.h>
 
 // These should be defined properly in your real DX11 setup
-extern HWNG g_hWnd;
-extern ID3D11Device * g_pd3dDevice;
-extern ID3D11DeviceContext * g_pd3dDeviceContext;
+extern HWND g_hWnd;
+extern ID3D11Device* g_pd3dDevice;
+extern ID3D11DeviceContext* g_pd3dDeviceContext;
 
 // Init ImGui context and backends
 void InitImGui() {
     IMGUI_CHECKVERSION();
     ImGui::CreateContext();
-    ImguiIO"& io = Imgui::GetIO(); (void)io;
+    ImGuiIO& io = ImGui::GetIO();
+    (void)io;
 
     ImGui::StyleColorsDark();
 
-    ImGui_ImplWin32:Init(g_hWnd);
-    Imgui_ImplDX11:Init(g_pd3dDevice, g_pd3dDeviceContext);
+    ImGui_ImplWin32_Init(g_hWnd);
+    ImGui_ImplDX11_Init(g_pd3dDevice, g_pd3dDeviceContext);
 }
 
 // Begin ImGui frame
-void StartImgui() {
-    ImGui_ImplDX11:NewFrame();
-    Imgui_ImplWin32:NewFrame();
+void StartImGui() {
+    ImGui_ImplDX11_NewFrame();
+    ImGui_ImplWin32_NewFrame();
     ImGui::NewFrame();
 }
 
 // Render your ImGui content
 void RenderImGui() {
-    Imgui::Begin("Game Cheating Tool");
+    ImGui::Begin("Game Cheating Tool");
     ImGui::Text("Hello, hacker world!");
-    Imgui::End();
+    ImGui::End();
 
     ImGui::Render();
-    ImGui_ImplDX11:RenderDrawData(ImGui::GetDrawData());
+    ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
 }

--- a/src/gui.h
+++ b/src/gui.h
@@ -1,8 +1,8 @@
 #ifndef GUI_H
 #define GUI_H
 
-void InitImgui();
-void StartImgui();
-void RenderImgui();
+void InitImGui();
+void StartImGui();
+void RenderImGui();
 
 #endif // GUI_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,12 +8,12 @@ int main() {
 #ifdef _WIN32
     FreeConsole();
 #endif
-    InitImgui();
-    StartImgui();
+    InitImGui();
+    StartImGui();
 
     // Example render loop
     for (int i = 0; i < 1; ++i) {
-        RenderImgui();
+        RenderImGui();
     }
 
     return 0;


### PR DESCRIPTION
## Summary
- fix includes and typos in `gui.cpp`
- keep function names consistent in `gui.h` and `main.cpp`

## Testing
- `cmake -B build_win ...` *(configure cross‑compilation)*
- `cmake --build build_win` *(fails: undefined references to external DX11 symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68474a773f308333ad481a9cfff7f73a