### PR TITLE
Fix missing global DX variables

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,10 @@
 #ifdef _WIN32
 #include <windows.h>
+#include <d3d11.h>
+// Minimal global DirectX variables used by the ImGui backend
+HWND g_hWnd = nullptr;
+ID3D11Device* g_pd3dDevice = nullptr;
+ID3D11DeviceContext* g_pd3dDeviceContext = nullptr;
 #endif
 #include "gui.h"
 #include <iostream>


### PR DESCRIPTION
## Summary
- define the global DirectX variables used by ImGui

## Testing
- `cmake ..`
- `cmake --build .` *(fails: `fatal error: d3d11.h: No such file or directory`)*
- `CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ cmake ..`
- `cmake --build .` *(fails: undefined references to Dwm/DirectX functions)*


------
https://chatgpt.com/codex/tasks/task_e_68474d1926848333b3df1ecdbcb5fe9a