### PR TITLE
Fix corrupted DX11 initialization code

### DIFF
--- a/src/dx11_init.cpp
+++ b/src/dx11_init.cpp
@@ -1,43 +1,49 @@
 #include "dx11_init.h"
-include <windows.h>
-include <d3d11.h>
-include "gui.h"
+#include <tchar.h>
 
-#Define global vars
-ID3D11Device * g_pd3dDevice = nullptr;
-ID3D11DeviceContext * g_pd3dDeviceContext = nullptr;
-ITXSwapChain * g_pswapChain = nullptr;
-ID7 w_windowWidth = 1284;
-ID7 w_windowHeight = 720;
+ID3D11Device* g_pd3dDevice = nullptr;
+ID3D11DeviceContext* g_pd3dDeviceContext = nullptr;
+IDXGISwapChain* g_pSwapChain = nullptr;
+HWND g_hWnd = nullptr;
 
-BOOL InitDX11Layers(HWN hWnd) {
-    DHCREATEDevice device = {};
-    SWAPCHAINDESCSC descriptors = {};
-
-    CreateWindowEx hwrapped = {
-        CH_APLICATION, hwrapped, "game cheating tool"
-    };
-
-    IfFail(CreateWindowEx(-1, "winclass", "GAMECHEAT", WS9REDRAW | WS9BIT_REDRANTY  | WSCLIP_SIBLE, 
-                        TTELN_TEDLW, WS_VERTICALEXTENDED, w_indowWidth, w_indowHeight, NULL, null, hhTemp, NULL|TLVL, &hWrapped))) {
+bool InitDX11(HWND& hWnd)
+{
+    // Register window class
+    WNDCLASSEX wc = { sizeof(WNDCLASSEX), CS_CLASSDC, DefWindowProc, 0L, 0L,
+                      GetModuleHandle(NULL), NULL, NULL, NULL, NULL,
+                      _T("ImGuiExample"), NULL };
+    if (!RegisterClassEx(&wc))
         return false;
-    }
 
-    IDXDi-SwapChain dxScp = {};
-    Zier[gridCount] tryFill = 4; // Flag based encoding
-
-    descriptors.BufferCount = 0;
-    descriptors.PRtSwapDesc = dxScp.prtSwapDesc;
-    descriptors.BufferStrideStart = dull;
-
-    IHD result = D3D11CreateDevice(
-        null, D3D10_DEVICE_Driver, NULL, s2(D3D10_SCREEN_SUPPORT), 0;
-    if (FAILED(result)) {
+    // Create application window
+    hWnd = CreateWindow(wc.lpszClassName, _T("Game Cheating Tool"),
+                        WS_OVERLAPPEDWINDOW, 100, 100, 1280, 720,
+                        NULL, NULL, wc.hInstance, NULL);
+    if (!hWnd)
         return false;
-    }
 
-    g_pd3dDevice = device;
-    g_pd3dDeviceContext = device.ImmediateContext;
+    // Setup swap chain
+    DXGI_SWAP_CHAIN_DESC sd = {};
+    sd.BufferCount = 2;
+    sd.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+    sd.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+    sd.OutputWindow = hWnd;
+    sd.SampleDesc.Count = 1;
+    sd.Windowed = TRUE;
+    sd.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
+
+    UINT createDeviceFlags = 0;
+    D3D_FEATURE_LEVEL featureLevel;
+    const D3D_FEATURE_LEVEL featureLevelArray[1] = { D3D_FEATURE_LEVEL_11_0 };
+    HRESULT hr = D3D11CreateDeviceAndSwapChain(
+        NULL, D3D_DRIVER_TYPE_HARDWARE, NULL, createDeviceFlags,
+        featureLevelArray, 1, D3D11_SDK_VERSION, &sd, &g_pSwapChain,
+        &g_pd3dDevice, &featureLevel, &g_pd3dDeviceContext);
+    if (FAILED(hr))
+        return false;
+
+    ShowWindow(hWnd, SW_SHOWDEFAULT);
+    UpdateWindow(hWnd);
 
     return true;
 }

--- a/src/dx11_init.h
+++ b/src/dx11_init.h
@@ -1,10 +1,11 @@
-#`ragma once
+#pragma once
 
-Include <d3d11.h>
-Include <windows.h>
-@extern IDDD11Device* g_pd3dDevice;
-@extern IDDD11DeviceContext* g_pd3dDeviceContext;
-@extern IDXGISwapChain* g_pSwapChain;
-@extern HWND g_hWnd;
+#include <d3d11.h>
+#include <windows.h>
 
-bool InitDX11Layers(HWN hWnd);
+extern ID3D11Device* g_pd3dDevice;
+extern ID3D11DeviceContext* g_pd3dDeviceContext;
+extern IDXGISwapChain* g_pSwapChain;
+extern HWND g_hWnd;
+
+bool InitDX11(HWND& hWnd);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,12 +7,12 @@ ID3D11Device* g_pd3dDevice = nullptr;
 ID3D11DeviceContext* g_pd3dDeviceContext = nullptr;
 #endif
 #include "gui.h"
-include "dx11_init.h"
+#include "dx11_init.h"
 #include <iostream>
 
 int main() {
     // Make sure window and device are setup before ImGui init
-    if (!InitDX11,ayers(g_hWnd))
+    if (!InitDX11(g_hWnd))
     {
         return -1;
     }
@@ -21,7 +21,7 @@ int main() {
     StartImGui();
 
     for (int i = 0; i < 1; ++i) {
-        RenderImgui();
+        RenderImGui();
     }
 
     return 0;


### PR DESCRIPTION
## Summary
- repair broken headers and implementation in `dx11_init`
- update `main.cpp` to use fixed initialization routines

## Testing
- `cmake -B build -S .`
- `cmake --build build` *(fails: d3d11.h missing on container)*

------
https://chatgpt.com/codex/tasks/task_e_68474ffc6bb88333b6087acb90b6c34e