### PR TITLE
Fix global variable link errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # game-cheating-tool
 
-A stylished, modern-designed cheating tool built with ImGui + DiRECTH 11.
+A stylish, modern-designed cheating tool built with ImGui and DirectX 11.
 
-\n\n**Project setup defaults**\n- C++, Direct1 Backend\n- MSVC Compiler\n- Visual Studio 2022\n\n**Structure**\n/game-cheating-tool\n   \src - core code\n   \-vendor - imgui/backends\n   CmakeLists.txt - vs/util-friendly project building\n\nQuick clone, paste into VSV22 and let it rip open.
+**Project setup defaults**
+- C++, DirectX backend
+- MSVC compiler
+- Visual Studio 2022
+
+**Structure**
+```
+/game-cheating-tool
+    src     - core code
+    vendor  - imgui/backends
+    CMakeLists.txt - VS/utility-friendly project building
+```
+
+Quick clone, open in VS2022 and build.
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,6 @@
 #ifdef _WIN32
 #include <windows.h>
 #include <d3d11.h>
-// Minimal global DirectX variables used by the ImGui backend
-HWND g_hWnd = nullptr;
-ID3D11Device* g_pd3dDevice = nullptr;
-ID3D11DeviceContext* g_pd3dDeviceContext = nullptr;
 #endif
 #include "gui.h"
 #include "dx11_init.h"


### PR DESCRIPTION
## Summary
- remove duplicate global DirectX variable definitions from `main.cpp`
- polish README formatting and typos

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build .` *(fails: d3d11.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_684750ef12ec833391ac4e5a13c001bf